### PR TITLE
Add delete-user cli command

### DIFF
--- a/app/cli_commands/__init__.py
+++ b/app/cli_commands/__init__.py
@@ -21,3 +21,15 @@ def create_admin_user(username, password):
     except IntegrityError:
         db.session.rollback()
         click.echo('User with that username already exists!')
+
+
+@app.cli.command('delete-user')
+@click.argument('username')
+def delete_user(username):
+    user = User.query.filter(User.username == username).first()
+    if not user:
+        click.echo('User with that username does not exist!')
+    else:
+        db.session.delete(user)
+        db.session.commit()
+        click.echo(f"User '{username}' deleted successfully!")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -26,8 +26,8 @@ class User(UserMixin, db.Model):
     username = db.Column(db.String(100), nullable=False, unique=True)
     pwd_hash = db.Column(db.String(150), nullable=False)
     is_admin = db.Column(db.Boolean, default=False, nullable=False)
-    solutions = db.relationship('UserSolution', backref='user', lazy=True)
-    challenge_feedback = db.relationship('UserFeedback', backref='user', lazy=True)
+    solutions = db.relationship('UserSolution', backref='user', cascade='delete', lazy=True)
+    challenge_feedback = db.relationship('UserFeedback', cascade='delete', backref='user', lazy=True)
     
     def set_password(self, password):
         self.pwd_hash = generate_password_hash(password)


### PR DESCRIPTION
Caveats

- Current implementation deletes all user feedback sent by the user and user solutions
   - This is because SQLite does not allow for ALTER COLUMN commands so we can't change user_id fields to be nullable with flask-migrate currently